### PR TITLE
Simplified the procedure to get a trainable CellPop object

### DIFF
--- a/flecs/cell_population.py
+++ b/flecs/cell_population.py
@@ -14,7 +14,7 @@ import torch
 ########################################################################################################################
 
 
-class CellPopulation(ABC):
+class CellPopulation(ABC, torch.nn.Module):
     def __init__(self, interaction_graph, n_cells=1, per_node_state_dim=1):
         """A population of independnet cells (no cell-cell interactions).
 
@@ -22,6 +22,7 @@ class CellPopulation(ABC):
             interaction_graph ():
             n_cells (int): Number of independent cells in the population.
         """
+        super().__init__()
         # str type of node (e.g., gene, protein).
         self._node_set_dict: Dict[str, NodeSet] = {}
         # str types of interactions (src, interaction_type, dest).
@@ -136,6 +137,14 @@ class CellPopulation(ABC):
             self[n_type].production_rate = torch.zeros(
                 self[n_type].production_rate.shape
             )
+
+    def parameters(self, recurse: bool = True):
+        for k, n_set in self._node_set_dict.items():
+            yield from n_set.parameters(recurse=recurse)
+        for k, e_set in self._edge_set_dict.items():
+            yield from e_set.parameters(recurse=recurse)
+        for name, param in self.named_parameters(recurse=recurse):
+            yield param
 
     def __repr__(self):
         return "CellPopulation. {} nodes and {} cells.\n".format(

--- a/flecs/trainable.py
+++ b/flecs/trainable.py
@@ -4,21 +4,16 @@ from flecs.utils import set_seed
 from flecs.trajectory import simulate_deterministic_trajectory
 import torch
 
-
-class TrainableTestCellPop(TestCellPop, torch.nn.Module):
-    def __init__(self):
-        flecs.cell_population.TestCellPop.__init__(self)
-        torch.nn.Module.__init__(self)
-
-        self["gene"].alpha = torch.nn.Parameter(self["gene"].alpha)
-
-        self.parameter_list = torch.nn.ParameterList([self["gene"].alpha])
-
-
 set_seed(0)
 
 ground_truth_cellpop = TestCellPop()
-trainable_cellpop = TrainableTestCellPop()
+trainable_cellpop = TestCellPop()
+
+# Cast some tensors of the CellPop object as a torch Parameters. That's it!
+trainable_cellpop["gene"].alpha = torch.nn.Parameter(trainable_cellpop["gene"].alpha)
+e_type = "gene", "activation", "gene"
+trainable_cellpop[e_type].weights = torch.nn.Parameter(trainable_cellpop[e_type].weights)
+
 
 optimizer = torch.optim.Adam(trainable_cellpop.parameters(), lr=0.01)
 loss = torch.nn.MSELoss()


### PR DESCRIPTION
CellPop, NodeSet and EdgeSet classes now inherit from `torch.nn.Module`.

I override their`parameters()` method, so that the parameters get registered automatically.